### PR TITLE
Build failed due to missing header file

### DIFF
--- a/include/Alias.h
+++ b/include/Alias.h
@@ -4,6 +4,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Argument.h"
 #include "llvm/IR/Function.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/Type.h"


### PR DESCRIPTION
Alias.h was missing raw_ostream header file due to which build failed.